### PR TITLE
Start data importer using two gunicorn workers

### DIFF
--- a/docker-compose-importer.yml
+++ b/docker-compose-importer.yml
@@ -10,6 +10,7 @@ services:
       - /bin/entrypoint.sh
     environment:
       DATA_IMPORTER_SERVICE_PORT: "9192"
+      NUMBER_WORKER_PROCESS: "1"
       DATA_IMPORTER_SERVICE_TIMEOUT: "3600"
       # controls whether to use http/ws or https/wss
       GREMLIN_USE_SECURE_CONNECTION: "false"

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -39,6 +39,8 @@ objects:
         - env:
           - name: DATA_IMPORTER_SERVICE_PORT
             value: ${DATA_IMPORTER_SERVICE_PORT}
+          - name: NUMBER_WORKER_PROCESS
+            value: ${NUMBER_WORKER_PROCESS}
           - name: DATA_IMPORTER_SERVICE_TIMEOUT
             value: ${DATA_IMPORTER_SERVICE_TIMEOUT}
           - name: GREMLIN_USE_SECURE_CONNECTION
@@ -116,6 +118,11 @@ parameters:
   name: DATA_IMPORTER_SERVICE_TIMEOUT
   required: true
   value: "3600"
+
+- description: Number of worker process for the data importer service
+  name: NUMBER_WORKER_PROCESS
+  required: true
+  value: "2"
 
 - description: Whether to use secure connection or not ?
   name: GREMLIN_USE_SECURE_CONNECTION

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Start data model service with time out
-gunicorn --pythonpath /src/ -b 0.0.0.0:$DATA_IMPORTER_SERVICE_PORT -t $DATA_IMPORTER_SERVICE_TIMEOUT rest_api:app
+gunicorn --pythonpath /src/ -b 0.0.0.0:$DATA_IMPORTER_SERVICE_PORT -t $DATA_IMPORTER_SERVICE_TIMEOUT -w $NUMBER_WORKER_PROCESS rest_api:app


### PR DESCRIPTION
data importer uses around 250 MB memory per pod. It makes more sense to spawn two workers process for data importer when started.