### PR TITLE
declared_license(s) can be None

### DIFF
--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -81,10 +81,10 @@ class GraphPopulator(object):
             details = input_json.get('analyses').get('metadata', {}).get('details', [])
             if details and details[0]:
                 declared_licenses = []
-                if 'declared_licenses' in details[0] and details[0]['declared_licenses']:
+                if details[0].get('declared_licenses'):
                     # list of license names
                     declared_licenses = details[0]['declared_licenses']
-                elif 'declared_license' in details[0] and details[0]['declared_license']:
+                elif details[0].get('declared_license'):
                     # string with comma separated license names
                     declared_licenses = details[0]['declared_license'].split(',')
 


### PR DESCRIPTION
Fixes:

```
File "/src/data_importer.py", line 78, in _import_keys_from_s3_http
    str_gremlin = GraphPopulator.create_query_string(obj)
  File "/src/graph_populator.py", line 210, in create_query_string
    str_gremlin += cls.construct_version_query(input_json)
  File "/src/graph_populator.py", line 89, in construct_version_query
    declared_licenses = details[0]['declared_license'].split(',')
AttributeError: 'NoneType' object has no attribute 'split'
```