### PR TITLE
fix for bug:2042

### DIFF
--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -17,6 +17,7 @@ class GraphPopulator(object):
         final_declared_licenses = list()
         for dl in license_list:
             if dl.startswith(("version", "Version")):
+                dl = " ".join([li.strip() for li in dl.split("\n")])
                 final_declared_licenses[-1] = final_declared_licenses[-1] + ", " \
                                               + dl
             else:

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -16,11 +16,10 @@ class GraphPopulator(object):
         """Correct the incorrect splitting of licenses."""
         final_declared_licenses = list()
         for dl in license_list:
+            dl = " ".join([li.strip() for li in dl.split("\n")])
             if dl.startswith(("version", "Version")):
-                dl = " ".join([li.strip() for li in dl.split("\n")])
                 final_declared_licenses[-1] = final_declared_licenses[-1] + ", " + dl
             else:
-                dl = " ".join([li.strip() for li in dl.split("\n")])
                 final_declared_licenses.append(dl)
         return final_declared_licenses
 

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -13,6 +13,7 @@ class GraphPopulator(object):
 
     @classmethod
     def correct_license_splitting(cls, license_list):
+        """This function is responsible for correcting the incorrect splitting of licenses"""
         final_declared_licenses = list()
         for dl in license_list:
             if dl.startswith(("version", "Version")):

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -13,7 +13,7 @@ class GraphPopulator(object):
 
     @classmethod
     def correct_license_splitting(cls, license_list):
-        """This function is responsible for correcting the incorrect splitting of licenses"""
+        """Correct the incorrect splitting of licenses."""
         final_declared_licenses = list()
         for dl in license_list:
             if dl.startswith(("version", "Version")):

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -146,7 +146,7 @@ class GraphPopulator(object):
                     else:  # default behavior
                         # split by comma
                         declared_licenses = [x.strip() for x in declared_str.split(",")]
-                    declared_licenses = cls.correct_license_splitting(declared_licenses)
+                declared_licenses = cls.correct_license_splitting(declared_licenses)
 
                 # Clear declared licenses field before refreshing
                 drop_props.append('declared_licenses')

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -116,7 +116,7 @@ class GraphPopulator(object):
                 if details[0].get('declared_licenses'):
                     # list of license names
                     declared_licenses = details[0]['declared_licenses']
-                elif details[0].get('declared_licenses'):
+                elif details[0].get('declared_license'):
                     # string with comma separated license names
                     # see: github.com/fabric8-analytics/fabric8-analytics-data-model/issues/71
                     # TODO: Factor out this license normalization elsewhere into a module ?

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -106,7 +106,15 @@ class GraphPopulator(object):
                     declared_licenses = details[0]['declared_licenses']
                 elif details[0].get('declared_license'):
                     # string with comma separated license names
-                    declared_licenses = details[0]['declared_license'].split(',')
+                    # declared_licenses = details[0]['declared_license'].split(',')
+                    declared_licenses = details[0].get('declared_license').split(', ')
+                    final_declared_licenses = list()
+                    for i in xrange(0, len(declared_licenses)):
+                        if declared_licenses[i].startswith("Version"):
+                            final_declared_licenses[-1] = final_declared_licenses[-1] + ", " + declared_licenses[i]
+                        else:
+                            final_declared_licenses.append(declared_licenses[i])
+                    declared_licenses = final_declared_licenses
 
                 # Clear declared licenses field before refreshing
                 drop_props.append('declared_licenses')

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -101,20 +101,20 @@ class GraphPopulator(object):
             details = input_json.get('analyses').get('metadata', {}).get('details', [])
             if details and details[0]:
                 declared_licenses = []
-                if details[0].get('declared_licenses'):
+                dl = details[0].get('declared_licenses')
+                if dl and isinstance(dl, list):
                     # list of license names
-                    declared_licenses = details[0]['declared_licenses']
-                elif details[0].get('declared_license'):
+                    declared_licenses = dl
+                elif dl and isinstance(dl, str):
                     # string with comma separated license names
-                    # declared_licenses = details[0]['declared_license'].split(',')
-                    declared_licenses = details[0].get('declared_license').split(', ')
+                    declared_licenses = dl.replace(", ", ",").lower().split(",")
                     final_declared_licenses = list()
-                    for i in xrange(0, len(declared_licenses)):
-                        if declared_licenses[i].startswith("Version"):
+                    for declared_license in declared_licenses:
+                        if declared_license.startswith("version"):
                             final_declared_licenses[-1] = final_declared_licenses[-1] + ", "\
-                                                          + declared_licenses[i]
+                                                          + declared_license
                         else:
-                            final_declared_licenses.append(declared_licenses[i])
+                            final_declared_licenses.append(declared_licenses)
                     declared_licenses = final_declared_licenses
 
                 # Clear declared licenses field before refreshing

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -18,8 +18,7 @@ class GraphPopulator(object):
         for dl in license_list:
             if dl.startswith(("version", "Version")):
                 dl = " ".join([li.strip() for li in dl.split("\n")])
-                final_declared_licenses[-1] = final_declared_licenses[-1] + ", " \
-                                              + dl
+                final_declared_licenses[-1] = final_declared_licenses[-1] + ", " + dl
             else:
                 final_declared_licenses.append(dl)
         return final_declared_licenses

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -111,7 +111,8 @@ class GraphPopulator(object):
                     final_declared_licenses = list()
                     for i in xrange(0, len(declared_licenses)):
                         if declared_licenses[i].startswith("Version"):
-                            final_declared_licenses[-1] = final_declared_licenses[-1] + ", " + declared_licenses[i]
+                            final_declared_licenses[-1] = final_declared_licenses[-1] + ", "\
+                                                          + declared_licenses[i]
                         else:
                             final_declared_licenses.append(declared_licenses[i])
                     declared_licenses = final_declared_licenses

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -107,14 +107,15 @@ class GraphPopulator(object):
                     declared_licenses = dl
                 elif dl and isinstance(dl, str):
                     # string with comma separated license names
-                    declared_licenses = dl.replace(", ", ",").lower().split(",")
+                    declared_licenses = dl.replace(", ", ",").split(",")
                     final_declared_licenses = list()
                     for declared_license in declared_licenses:
-                        if declared_license.startswith("version"):
+                        if declared_license.startswith("version") or declared_license.\
+                                startswith("Version"):
                             final_declared_licenses[-1] = final_declared_licenses[-1] + ", "\
                                                           + declared_license
                         else:
-                            final_declared_licenses.append(declared_licenses)
+                            final_declared_licenses.append(declared_license)
                     declared_licenses = final_declared_licenses
 
                 # Clear declared licenses field before refreshing

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -20,6 +20,7 @@ class GraphPopulator(object):
                 dl = " ".join([li.strip() for li in dl.split("\n")])
                 final_declared_licenses[-1] = final_declared_licenses[-1] + ", " + dl
             else:
+                dl = " ".join([li.strip() for li in dl.split("\n")])
                 final_declared_licenses.append(dl)
         return final_declared_licenses
 

--- a/src/graph_populator.py
+++ b/src/graph_populator.py
@@ -12,6 +12,17 @@ class GraphPopulator(object):
     """Class containing classmethods used to construct queries to the graph database."""
 
     @classmethod
+    def correct_license_splitting(cls, license_list):
+        final_declared_licenses = list()
+        for dl in license_list:
+            if dl.startswith(("version", "Version")):
+                final_declared_licenses[-1] = final_declared_licenses[-1] + ", " \
+                                              + dl
+            else:
+                final_declared_licenses.append(dl)
+        return final_declared_licenses
+
+    @classmethod
     def construct_version_query(cls, input_json):
         """Construct the query to retrieve detailed information of given version of a package."""
         pkg_name = input_json.get('package')
@@ -101,11 +112,10 @@ class GraphPopulator(object):
             details = input_json.get('analyses').get('metadata', {}).get('details', [])
             if details and details[0]:
                 declared_licenses = []
-                dl = details[0].get('declared_licenses')
-                if dl and isinstance(dl, list):
+                if details[0].get('declared_licenses'):
                     # list of license names
-                    declared_licenses = dl
-                elif dl and isinstance(dl, str):
+                    declared_licenses = details[0]['declared_licenses']
+                elif details[0].get('declared_licenses'):
                     # string with comma separated license names
                     # see: github.com/fabric8-analytics/fabric8-analytics-data-model/issues/71
                     # TODO: Factor out this license normalization elsewhere into a module ?
@@ -119,7 +129,7 @@ class GraphPopulator(object):
 
                     above string becomes
 
-                    ['Apache License, Version 2.0 and',
+                    ['Apache License, Version 2.0',
                     'Common Development And Distribution License (CDDL) Version 1.0']
 
                     """
@@ -135,14 +145,7 @@ class GraphPopulator(object):
                     else:  # default behavior
                         # split by comma
                         declared_licenses = [x.strip() for x in declared_str.split(",")]
-                    final_declared_licenses = list()
-                    for declared_license in declared_licenses:
-                        if declared_license.startswith(("version", "Version")):
-                            final_declared_licenses[-1] = final_declared_licenses[-1] + ", "\
-                                                          + declared_license
-                        else:
-                            final_declared_licenses.append(declared_license)
-                    declared_licenses = final_declared_licenses
+                    declared_licenses = cls.correct_license_splitting(declared_licenses)
 
                 # Clear declared licenses field before refreshing
                 drop_props.append('declared_licenses')


### PR DESCRIPTION
License analysis is getting failed because of incorrect splitting while adding node to graph. This fix takes care of the splitting of licenses correctly.
```
If license is "Apache License, Version 2"
Result : ["Apache License", "Version 2"]   (incorrect)
It should be 
["Apache License, Version 2"]   (Correct)
```