### PR TITLE
Change template file to reflect dev cluster url and port

### DIFF
--- a/src/config.py.template
+++ b/src/config.py.template
@@ -16,8 +16,8 @@ LOGFILE_PATH = os.environ.get("LOGFILE_PATH", "/tmp/error.log")
 _gremlin_securely = "true" == os.environ.get("GREMLIN_USE_SECURE_CONNECTION", "false").lower()
 GREMLIN_SERVER_URL_REST = "{proto}://{host}:{port}".format(
     proto="https" if _gremlin_securely else "http",
-    host=os.environ.get("BAYESIAN_GREMLIN_HTTPINGESTION_SERVICE_HOST", "localhost"),
-    port=os.environ.get("BAYESIAN_GREMLIN_HTTPINGESTION_SERVICE_PORT", "8181"))
+    host=os.environ.get("BAYESIAN_GREMLIN_HTTPINGESTION_SERVICE_HOST", "bayesian-gremlin-http"),
+    port=os.environ.get("BAYESIAN_GREMLIN_HTTPINGESTION_SERVICE_PORT", "8182"))
 
 # To load data from S3
 AWS_S3_ACCESS_KEY_ID = os.environ.get("AWS_S3_ACCESS_KEY_ID", "")


### PR DESCRIPTION
Change default values for BAYESIAN_GREMLIN_HTTPINGESTION_SERVICE_HOST and BAYESIAN_GREMLIN_HTTPINGESTION_SERVICE_PORT

The current values point to localhost instance and failing for dev cluster deployments. Since now we have dev cluster as our primary playground, I am changing the variables to reflect the same.