### PR TITLE
WIP:Deploy on RHEL based container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,21 @@ REGISTRY?=registry.devshift.net
 REPOSITORY?=bayesian/data-model-importer
 DEFAULT_TAG=latest
 
+ifeq ($(TARGET), rhel)
+    DOCKERFILE := Dockerfile.data-model.rhel
+else
+    DOCKERFILE := Dockerfile.data-model
+endif
+
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository
 
 all: fast-docker-build
 
 docker-build:
-	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f Dockerfile.data-model .
+	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 
 fast-docker-build:
-	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f Dockerfile.data-model .
+	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 
 test:
 	./runtests.sh

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -4,6 +4,8 @@ set -ex
 
 . cico_setup.sh
 
+docker_login
+
 build_image
 
 ./runtests.sh

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -4,6 +4,8 @@ set -ex
 
 . cico_setup.sh
 
+docker_login
+
 # not needed for tests, but we can check that the image actually builds
 build_image
 

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -ex
 
+REGISTRY="push.registry.devshift.net"
+
 load_jenkins_vars() {
     if [ -e "jenkins-env" ]; then
         cat jenkins-env \
@@ -7,6 +9,15 @@ load_jenkins_vars() {
           | sed 's/^/export /g' \
           > ~/.jenkins-env
         source ~/.jenkins-env
+    fi
+}
+
+docker_login() {
+    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
+        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+    else
+        echo "Could not login, missing credentials for the registry"
+        exit 1
     fi
 }
 
@@ -32,30 +43,26 @@ tag_push() {
 push_image() {
     local image_name
     local image_repository
-    local short_commit 
-    local push_registry
+    local short_commit
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
     short_commit=$(git rev-parse --short=7 HEAD)
-    push_registry="push.registry.devshift.net"
 
-    # login first
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
+    if [ "$TARGET" = "rhel" ]; then
+        IMAGE_URL="${REGISTRY}/osio-prod/${image_repository}"
     else
-        echo "Could not login, missing credentials for the registry"
-        exit 1
+        IMAGE_URL="${REGISTRY}/${image_repository}"
     fi
 
     if [ -n "${ghprbPullId}" ]; then
         # PR build
         pr_id="SNAPSHOT-PR-${ghprbPullId}"
-        tag_push ${push_registry}/${image_repository}:${pr_id} ${image_name}
-        tag_push ${push_registry}/${image_repository}:${pr_id}-${short_commit} ${image_name}
+        tag_push ${IMAGE_URL}:${pr_id} ${image_name}
+        tag_push ${IMAGE_URL}:${pr_id}-${short_commit} ${image_name}
     else
         # master branch build
-        tag_push ${push_registry}/${image_repository}:latest ${image_name}
-        tag_push ${push_registry}/${image_repository}:${short_commit} ${image_name}
+        tag_push ${IMAGE_URL}:latest ${image_name}
+        tag_push ${IMAGE_URL}:${short_commit} ${image_name}
     fi
 
     echo 'CICO: Image pushed, ready to update deployed app'


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
into staging.

This PR includes a new RHEL based dockerfile for the deployment of the
service. This dockerfile will be built when this variable is set:
TARGET=rhel.  The build scripts have been adapted to take this into
consideration, and to push the image to different namespaces if the
TARGET is rhel or not.

Currently the deployment builds happen on empty baremetal machines. The
build script will be executed a second time to build and push the
deployment file if TARGET=rhel, so some changes in the build script are
to ensure that it will work if executed a second time.

By merging this PR this service will be deployed to staging. Once we
verify that the RHEL based image works correctly, we can push to prod.