### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.data-model.rhel
+++ b/Dockerfile.data-model.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/fabric8-analytics-data-model:latest
+FROM quay.io/openshiftio/rhel-base-fabric8-analytics-data-model:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-REGISTRY?=registry.devshift.net
-REPOSITORY?=bayesian/data-model-importer
+REGISTRY?=quay.io
 DEFAULT_TAG=latest
 
 ifeq ($(TARGET), rhel)
     DOCKERFILE := Dockerfile.data-model.rhel
+	REPOSITORY := rhel-bayesian-data-model-importer
 else
     DOCKERFILE := Dockerfile.data-model
+	REPOSITORY := bayesian-data-model-importer
 endif
 
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository
@@ -26,4 +27,3 @@ get-image-name:
 
 get-image-repository:
 	@echo $(REPOSITORY)
-

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -11,4 +11,3 @@ build_image
 ./runtests.sh
 
 push_image
-

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,20 +1,27 @@
 #!/bin/bash -ex
 
-REGISTRY="push.registry.devshift.net"
+REGISTRY="quay.io"
 
 load_jenkins_vars() {
-    if [ -e "jenkins-env" ]; then
-        <jenkins-env \
-          grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-          | sed 's/^/export /g' \
-          > ~/.jenkins-env
-        source ~/.jenkins-env
+    if [ -e "jenkins-env.json" ]; then
+        eval "$(./env-toolkit load -f jenkins-env.json \
+                DEVSHIFT_TAG_LEN \
+                QUAY_USERNAME \
+                QUAY_PASSWORD \
+                JENKINS_URL \
+                GIT_BRANCH \
+                GIT_COMMIT \
+                BUILD_NUMBER \
+                ghprbSourceBranch \
+                ghprbActualCommit \
+                BUILD_URL \
+                ghprbPullId)"
     fi
 }
 
 docker_login() {
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u "${DEVSHIFT_USERNAME}" -p "${DEVSHIFT_PASSWORD}" "${REGISTRY}"
+    if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+        docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" "${REGISTRY}"
     else
         echo "Could not login, missing credentials for the registry"
         exit 1
@@ -44,14 +51,15 @@ push_image() {
     local image_name
     local image_repository
     local short_commit
+
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
     short_commit=$(git rev-parse --short=7 HEAD)
 
     if [ "$TARGET" = "rhel" ]; then
-        IMAGE_URL="${REGISTRY}/osio-prod/${image_repository}"
+        IMAGE_URL="${REGISTRY}/openshiftio/rhel-bayesian-data-model-importer"
     else
-        IMAGE_URL="${REGISTRY}/${image_repository}"
+        IMAGE_URL="${REGISTRY}/openshiftio/bayesian-data-model-importer"
     fi
 
     if [ -n "${ghprbPullId}" ]; then


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-analytics/pull/405