### PR TITLE
Don't cache gremlin scripts until bindings variables are identified

### DIFF
--- a/src/cve.py
+++ b/src/cve.py
@@ -12,7 +12,7 @@ class CVEPut(object):
     """Class encapsulating operations related to adding or replacing CVEs."""
 
     def __init__(self, cve_dict):
-        """Constructor."""
+        """Create CVEPut object based on cve_dict."""
         self._cve_dict = cve_dict
         self.validate_input()
 
@@ -159,7 +159,7 @@ class CVEDelete(object):
     """Class encapsulating operations related to deleting CVEs."""
 
     def __init__(self, cve_id_dict):
-        """Constructor."""
+        """Create CVEDelete object based on cve_id_dict."""
         self._cve_id_dict = cve_id_dict
         self.validate_input()
 
@@ -196,7 +196,7 @@ class CVEGet(object):
     """Class encapsulating operations related to retrieving information about CVEs."""
 
     def __init__(self, ecosystem, name, version):
-        """Constructor."""
+        """Create CVEGet object based on epv."""
         self._ecosystem = ecosystem
         self._name = name
         self._version = version

--- a/src/data_importer.py
+++ b/src/data_importer.py
@@ -139,7 +139,16 @@ def _import_keys_from_s3_http(data_source, epv_list):
                     epv_full = pkg_ecosystem + ":" + pkg_name + ":" + pkg_version
                     logger.info("Ingestion initialized for EPV - %s" % epv_full)
                     epv.append(epv_full)
-                    payload = {'gremlin': str_gremlin}
+                    payload = {
+                        'gremlin': str_gremlin,
+                        'bindings': {
+                            # (fixme) Disable groovy script caching until we move
+                            # to parameterized scripts.
+                            # http://tinkerpop.apache.org/docs/current/reference/#gremlin-server-cache
+                            # http://tinkerpop.apache.org/docs/current/reference/#parameterized-scripts
+                            '#jsr223.groovy.engine.keep.globals': 'phantom'
+                        }
+                    }
                     response = requests.post(config.GREMLIN_SERVER_URL_REST,
                                              data=json.dumps(payload), timeout=30)
                     resp = response.json()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,7 +15,7 @@ class RequestsMockResponse:
     """Mocked response from requests.post()."""
 
     def __init__(self, json_data, status_code):
-        """Constructor."""
+        """Create RequestsMockResponse object."""
         self.json_data = json_data
         self.status_code = status_code
         self.content = 'This is expected ;)'


### PR DESCRIPTION
# Description

Queries generated from GraphPopulator are not [parameterized](https://github.com/fabric8-analytics/fabric8-analytics-data-model/blob/9e7e5dcc4433b93bea313c530d5bc795458ab236/src/graph_populator.py), but few other modules(like cve.py) does use script [parameterization](https://github.com/fabric8-analytics/fabric8-analytics-data-model/blob/9e7e5dcc4433b93bea313c530d5bc795458ab236/src/cve.py#L152).

Script parameterization [is recommended by Gremlin](http://tinkerpop.apache.org/docs/current/reference/#parameterized-scripts
) community. Currently I'm running experiments on my dev cluster to see whether it is a potential reason for the memory bloat.

Fixes # (issue)
This is a workaround for https://issues.redhat.com/browse/APPAI-956. Proper solution would be to identifying all binding variables in the generated gremlin query and argument it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)